### PR TITLE
Fix PSI fetch error on invalid responses

### DIFF
--- a/collect-psi.js
+++ b/collect-psi.js
@@ -85,14 +85,21 @@ export async function originalFetchPSI(url, apiKey, fetchFn) {
     throw new Error('Rate limit');
   }
   const json = await res.json();
-  const cat = json.lighthouseResult.categories;
+
+  // Validate the PSI response structure to avoid undefined errors
+  const cat = json?.lighthouseResult?.categories;
+  if (!cat) {
+    const errorMsg = json?.error?.message || 'Invalid PSI response';
+    throw new Error(errorMsg);
+  }
+
   return {
     url,
-    performance: cat.performance.score,
-    accessibility: cat.accessibility.score,
-    seo: cat.seo.score,
+    performance: cat.performance?.score ?? null,
+    accessibility: cat.accessibility?.score ?? null,
+    seo: cat.seo?.score ?? null,
     bestPractices: cat['best-practices']?.score ?? null,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   };
 }
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -46,7 +46,11 @@ const config = {
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    'babel-jest': {
+      useESM: true,
+    },
+  },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",


### PR DESCRIPTION
## Summary
- ensure fetchPSI handles responses without lighthouse categories
- configure Jest to use babel-jest with ESM settings

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_683fcd1a27b8832582399b859ffe2311