### PR TITLE
Implement partial PSI save and handle failures

### DIFF
--- a/.github/workflows/psi.yml
+++ b/.github/workflows/psi.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Coletar dados PSI
         timeout-minutes: 10
+        continue-on-error: true
         env:
           PSI_CONCURRENCY: 10
           PSI_MAX_RETRIES: 2
@@ -94,6 +95,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit e push dos resultados
+        if: always()
         run: |
           if [ -f "data/psi-results.json" ]; then
             git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview/Purpose
 
-This project aims to automatically audit Brazilian city (prefeitura) websites using the Google PageSpeed Insights (PSI) API. The project has transitioned from an initial approach using a local Lighthouse CLI to massively leveraging the PSI API for more comprehensive data collection, including metrics for performance, accessibility, SEO, and best practices, with controlled parallelism (configurable). The results are processed and can be used to assess the current state of these public portals.
+This project aims to automatically audit Brazilian city (prefeitura) websites using the Google PageSpeed Insights (PSI) API. The project has transitioned from an initial approach using a local Lighthouse CLI to massively leveraging the PSI API for more comprehensive data collection. Metrics for performance, accessibility, SEO, and best practices are gathered sequentially with a one-second pause between requests, and partial results are written to disk after each successful call.
 
 This project was elaborated as part of a Master's dissertation research focusing on evaluating the transparency and accessibility of municipal websites.
 
@@ -59,7 +59,7 @@ The main steps performed by the workflow are:
 This Node.js script is the core of the data collection process. It performs the following actions:
 - Reads the list of municipalities and their URLs from `sites_das_prefeituras_brasileiras.csv`.
 - For each URL, it makes a request to the Google PageSpeed Insights API to fetch various web performance and quality metrics.
- - It manages the API requests with controlled parallelism. The concurrency defaults to 4 simultaneous requests but can be adjusted via the `PSI_CONCURRENCY` environment variable or a `--concurrency=<n>` CLI flag. The production GitHub Actions workflow sets `PSI_CONCURRENCY=10` to process many audits in parallel. When the PSI API responds with a `Rate limit` error, the script automatically retries using an exponential backoff. The retry behavior can be tuned with `PSI_MAX_RETRIES` (default `2`) and `PSI_RETRY_DELAY_MS` (default `1000`). To avoid overwhelming the API, the script also throttles requests based on `PSI_REQUESTS_PER_MIN` (default `60`), ensuring no more than this number of calls are started within any one-minute window.
+ - Requests are spaced one second apart to respect the PSI API rate limits. Each successful response is immediately appended to `data/psi-results.json` and `data/psi-results.csv`, ensuring that partial progress is preserved if the script stops early. Retries on transient errors use an exponential backoff controlled by `PSI_MAX_RETRIES` and `PSI_RETRY_DELAY_MS`.
 - The script collects the following key metrics for the mobile strategy:
     - Performance score
     - Accessibility score

--- a/collect-psi.test.js
+++ b/collect-psi.test.js
@@ -147,15 +147,15 @@ describe('collect-psi.js', () => {
 
       await runMainLogic(['node', 'collect-psi.js', '--test'], process.env.PSI_KEY, mockExternalFetchPSI);
 
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
-      const jsonCall = fs.writeFileSync.mock.calls.find(call => call[0] === 'data/test-psi-results.json');
-      const writtenData = JSON.parse(jsonCall[1]);
+      const jsonCalls = fs.writeFileSync.mock.calls.filter(call => call[0] === 'data/test-psi-results.json');
+      expect(jsonCalls.length).toBeGreaterThan(0);
+      const writtenData = JSON.parse(jsonCalls[jsonCalls.length - 1][1]);
       expect(writtenData.length).toBe(2);
       expect(writtenData[0].url).toBe('http://example.com');
       expect(writtenData[1].url).toBe('http://another-example.com');
       expect(consoleLogSpy).toHaveBeenCalledWith('[INFO] [fetchPSISuccess] ✅ http://example.com → 0.9');
       expect(consoleLogSpy).toHaveBeenCalledWith('[INFO] [fetchPSISuccess] ✅ http://another-example.com → 0.9');
-      expect(consoleLogSpy.mock.calls.some(c => c[0].includes('Saved 2 new results'))).toBe(true);
+      expect(consoleLogSpy.mock.calls.some(c => c[0].includes('Processed'))).toBe(true);
     });
 
     it('should correctly handle errors from fetchPSI and log them', async () => {
@@ -169,13 +169,13 @@ describe('collect-psi.js', () => {
 
       await runMainLogic(['node', 'collect-psi.js', '--test'], process.env.PSI_KEY, mockExternalFetchPSI);
 
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3); // JSON, CSV, and state files should be written
-      const jsonCallError = fs.writeFileSync.mock.calls.find(call => call[0] === 'data/test-psi-results.json');
-      const writtenData = JSON.parse(jsonCallError[1]);
+      const jsonCalls = fs.writeFileSync.mock.calls.filter(call => call[0] === 'data/test-psi-results.json');
+      expect(jsonCalls.length).toBeGreaterThan(0); // JSON file should be written
+      const writtenData = JSON.parse(jsonCalls[jsonCalls.length - 1][1]);
       expect(writtenData.length).toBe(2); // Only successful results are saved
       // Note: The original code logged to console.warn. logMessage('ERROR', ...) logs to console.error.
       expect(consoleErrorSpy).toHaveBeenCalledWith('[ERROR] [fetchPSI] Error for URL http://invalid-url-that-does-not-exist-hopefully.com: Simulated fetch error for non-existent URL');
-      expect(consoleLogSpy.mock.calls.some(c => c[0].includes('Saved 2 new results'))).toBe(true);
+      expect(consoleLogSpy.mock.calls.some(c => c[0].includes('Processed'))).toBe(true);
     });
 
     it('should create data directory if it does not exist', async () => {


### PR DESCRIPTION
## Summary
- save PSI results incrementally and write state after each request
- simplify throttle to 1s delay between requests
- allow GitHub Actions workflow to continue even when collection fails
- update tests for new behavior
- document incremental saves and simplified rate limit in README

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684236c92554832595b219ac6310da32