### PR TITLE
fix: resolve BDD async tests and DuckDB ID constraints

### DIFF
--- a/src/sites_prefeituras/storage.py
+++ b/src/sites_prefeituras/storage.py
@@ -230,19 +230,23 @@ class DuckDBStorage:
         """Salva uma auditoria completa."""
         # Inserir auditoria completa using asyncio.to_thread for blocking operation
         def insert_audit() -> int:
-            result = self.conn.execute("""
-                INSERT INTO audits (url, timestamp, mobile_result, desktop_result, error_message, retry_count)
-                VALUES (?, ?, ?, ?, ?, ?)
-                RETURNING id
+            # DuckDB requires explicit ID - get next ID first
+            next_id = self.conn.execute(
+                "SELECT COALESCE(MAX(id), 0) + 1 FROM audits"
+            ).fetchone()[0]
+            self.conn.execute("""
+                INSERT INTO audits (id, url, timestamp, mobile_result, desktop_result, error_message, retry_count)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
             """, [
+                next_id,
                 str(audit.url),
                 audit.timestamp,
                 audit.mobile_result.model_dump_json() if audit.mobile_result else None,
                 audit.desktop_result.model_dump_json() if audit.desktop_result else None,
                 audit.error_message,
                 audit.retry_count,
-            ]).fetchone()
-            return result[0] if result else 0
+            ])
+            return next_id
 
         audit_id = await asyncio.to_thread(insert_audit)
 
@@ -334,16 +338,21 @@ class DuckDBStorage:
     async def _save_summary(self, summary: AuditSummary) -> None:
         """Salva resumo da auditoria."""
         def insert_summary() -> None:
+            # DuckDB requires explicit ID - get next ID first
+            next_id = self.conn.execute(
+                "SELECT COALESCE(MAX(id), 0) + 1 FROM audit_summaries"
+            ).fetchone()[0]
             self.conn.execute("""
                 INSERT INTO audit_summaries (
-                    url, timestamp,
+                    id, url, timestamp,
                     mobile_performance, mobile_accessibility, mobile_best_practices, mobile_seo,
                     desktop_performance, desktop_accessibility, desktop_best_practices, desktop_seo,
                     mobile_fcp, mobile_lcp, mobile_cls, mobile_fid,
                     desktop_fcp, desktop_lcp, desktop_cls, desktop_fid,
                     has_errors, error_message
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, [
+                next_id,
                 str(summary.url), summary.timestamp,
                 summary.mobile_performance, summary.mobile_accessibility,
                 summary.mobile_best_practices, summary.mobile_seo,
@@ -358,13 +367,19 @@ class DuckDBStorage:
 
     async def get_recently_audited_urls(self, hours: int = 24) -> set[str]:
         """Retorna URLs auditadas nas ultimas N horas (para coleta incremental)."""
-        results = self.conn.execute("""
+        # DuckDB doesn't support parameterized intervals, use safe string formatting
+        # hours is an int, so no SQL injection risk
+        query = f"""
             SELECT DISTINCT url
             FROM audits
-            WHERE timestamp > CURRENT_TIMESTAMP - INTERVAL ? HOUR
+            WHERE timestamp > CURRENT_TIMESTAMP - INTERVAL '{int(hours)} hours'
               AND error_message IS NULL
-        """, [hours]).fetchall()
+        """
 
+        def execute_query() -> list:
+            return self.conn.execute(query).fetchall()
+
+        results = await asyncio.to_thread(execute_query)
         urls = {row[0] for row in results}
         logger.info(f"Found {len(urls)} URLs audited in last {hours} hours")
         return urls
@@ -641,33 +656,61 @@ class DuckDBStorage:
         Returns:
             Estatisticas da atualizacao
         """
+        # DuckDB doesn't support parameterized intervals, use safe string formatting
+        lookback_days = int(min_consecutive_days * 2)
+
         def update_quarantine_sync() -> QuarantineUpdateStats:
-            # Encontrar sites com falhas consecutivas nos ultimos N dias
-            results = self.conn.execute("""
+            # Encontrar sites com falhas em dias consecutivos nos ultimos N dias
+            # Using date arithmetic to identify consecutive sequences
+            results = self.conn.execute(f"""
                 WITH daily_failures AS (
-                    SELECT
+                    SELECT DISTINCT
                         url,
                         DATE(timestamp) as failure_date,
-                        error_message,
-                        ROW_NUMBER() OVER (PARTITION BY url ORDER BY timestamp DESC) as rn
+                        MAX(error_message) as error_message
                     FROM audits
                     WHERE error_message IS NOT NULL
+                      AND timestamp >= CURRENT_DATE - INTERVAL '{lookback_days} days'
+                    GROUP BY url, DATE(timestamp)
                 ),
-                consecutive_failures AS (
+                -- Assign group IDs to consecutive dates (date - row_number gives same value)
+                numbered AS (
+                    SELECT
+                        url,
+                        failure_date,
+                        error_message,
+                        failure_date - INTERVAL (ROW_NUMBER() OVER (
+                            PARTITION BY url ORDER BY failure_date
+                        )) DAY as grp
+                    FROM daily_failures
+                ),
+                -- Find consecutive sequences with >= min_consecutive_days
+                consecutive_sequences AS (
                     SELECT
                         url,
                         MIN(failure_date) as first_failure,
                         MAX(failure_date) as last_failure,
-                        COUNT(DISTINCT failure_date) as failure_days,
-                        MAX(CASE WHEN rn = 1 THEN error_message END) as last_error
-                    FROM daily_failures
-                    WHERE failure_date >= CURRENT_DATE - INTERVAL ? DAY
-                    GROUP BY url
-                    HAVING COUNT(DISTINCT failure_date) >= ?
+                        COUNT(*) as consecutive_days,
+                        MAX(error_message) as last_error
+                    FROM numbered
+                    GROUP BY url, grp
+                    HAVING COUNT(*) >= ?
+                ),
+                -- Get the longest sequence per URL
+                best_sequence AS (
+                    SELECT
+                        url,
+                        first_failure,
+                        last_failure,
+                        consecutive_days,
+                        last_error,
+                        ROW_NUMBER() OVER (PARTITION BY url ORDER BY consecutive_days DESC) as rn
+                    FROM consecutive_sequences
                 )
-                SELECT url, first_failure, last_failure, failure_days, last_error
-                FROM consecutive_failures
-            """, [min_consecutive_days * 2, min_consecutive_days]).fetchall()
+                SELECT url, first_failure, last_failure, consecutive_days, last_error
+                FROM best_sequence
+                WHERE rn = 1
+            """, [min_consecutive_days]).fetchall()
 
             added = 0
             updated = 0
@@ -691,12 +734,15 @@ class DuckDBStorage:
                     """, [last_failure, failure_days, last_error, url])
                     updated += 1
                 else:
-                    # Adicionar novo registro
+                    # Adicionar novo registro - get next ID
+                    next_id = self.conn.execute(
+                        "SELECT COALESCE(MAX(id), 0) + 1 FROM quarantine"
+                    ).fetchone()[0]
                     self.conn.execute("""
-                        INSERT INTO quarantine (url, first_failure, last_failure,
+                        INSERT INTO quarantine (id, url, first_failure, last_failure,
                                                consecutive_failures, last_error_message)
-                        VALUES (?, ?, ?, ?, ?)
-                    """, [url, first_failure, last_failure, failure_days, last_error])
+                        VALUES (?, ?, ?, ?, ?, ?)
+                    """, [next_id, url, first_failure, last_failure, failure_days, last_error])
                     added += 1
 
             return QuarantineUpdateStats(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,11 +32,20 @@ def temp_db_path() -> Generator[str, None, None]:
 
 @pytest_asyncio.fixture
 async def storage(temp_db_path: str) -> AsyncGenerator[DuckDBStorage, None]:
-    """Storage inicializado para testes."""
+    """Storage inicializado para testes (async)."""
     db = DuckDBStorage(temp_db_path)
     await db.initialize()
     yield db
     await db.close()
+
+
+@pytest.fixture
+def storage_sync(temp_db_path: str) -> Generator[DuckDBStorage, None, None]:
+    """Storage inicializado para testes BDD (sync wrapper)."""
+    db = DuckDBStorage(temp_db_path)
+    asyncio.run(db.initialize())
+    yield db
+    asyncio.run(db.close())
 
 
 # ============================================================================
@@ -61,7 +70,7 @@ def create_psi_response(
         "loadingExperience": {},
         "originLoadingExperience": {},
         "analysisUTCTimestamp": "2025-01-22T12:00:00.000Z",
-        "version": {"major": 9, "minor": 0},
+        "version": {"major": "9", "minor": "0"},
         "lighthouseResult": {
             "requestedUrl": url,
             "finalUrl": url,

--- a/tests/step_defs/test_quarantine.py
+++ b/tests/step_defs/test_quarantine.py
@@ -1,9 +1,10 @@
 """Step definitions para sistema de quarentena."""
 
+import asyncio
 from datetime import datetime, timedelta
 
 import pytest
-from pytest_bdd import scenarios, given, when, then, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
 from sites_prefeituras.storage import DuckDBStorage
 
@@ -14,6 +15,7 @@ scenarios("../features/quarantine.feature")
 # ============================================================================
 # Contexto
 # ============================================================================
+
 
 @pytest.fixture
 def quarantine_context():
@@ -27,68 +29,63 @@ def quarantine_context():
 
 
 @given("que existem auditorias no banco de dados")
-def audits_exist(quarantine_context, storage):
-    quarantine_context["storage"] = storage
+def audits_exist(quarantine_context, storage_sync):
+    quarantine_context["storage"] = storage_sync
 
 
 # ============================================================================
 # Cenario: Falhas consecutivas
 # ============================================================================
 
+
 @given(parsers.parse("auditorias de um site que falhou por {days:d} dias consecutivos"))
-@pytest.mark.asyncio
-async def given_consecutive_failures(quarantine_context, days, storage):
-    quarantine_context["storage"] = storage
+def given_consecutive_failures(quarantine_context, days, storage_sync):
+    quarantine_context["storage"] = storage_sync
     url = "https://site-com-problemas.gov.br"
     quarantine_context["test_url"] = url
 
     # Inserir falhas consecutivas
     for i in range(days):
-        await storage.conn.execute("""
-            INSERT INTO audits (url, timestamp, error_message)
-            VALUES (?, ?, ?)
-        """, [
-            url,
-            datetime.utcnow() - timedelta(days=i),
-            "Connection timeout"
-        ])
+        storage_sync.conn.execute(
+            """
+            INSERT INTO audits (id, url, timestamp, error_message)
+            VALUES (?, ?, ?, ?)
+        """,
+            [i + 1, url, datetime.utcnow() - timedelta(days=i), "Connection timeout"],
+        )
 
 
 @when(parsers.parse("eu atualizar a quarentena com minimo de {days:d} dias"))
-@pytest.mark.asyncio
-async def when_update_quarantine(quarantine_context, days):
+def when_update_quarantine(quarantine_context, days):
     storage = quarantine_context["storage"]
-    result = await storage.update_quarantine(min_consecutive_days=days)
+    result = asyncio.run(storage.update_quarantine(min_consecutive_days=days))
     quarantine_context["update_result"] = result
 
 
 @then("o site deve ser adicionado a quarentena")
-@pytest.mark.asyncio
-async def then_site_in_quarantine(quarantine_context):
+def then_site_in_quarantine(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     urls = [s["url"] for s in sites]
     assert url in urls
 
 
 @then(parsers.parse('o status deve ser "{status}"'))
-@pytest.mark.asyncio
-async def then_status_is(quarantine_context, status):
+def then_status_is(quarantine_context, status):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     site = next((s for s in sites if s["url"] == url), None)
     assert site is not None
     assert site["status"] == status
 
 
 @then(parsers.parse("o numero de falhas consecutivas deve ser {count:d}"))
-@pytest.mark.asyncio
-async def then_failure_count(quarantine_context, count):
+def then_failure_count(quarantine_context, count):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     site = next((s for s in sites if s["url"] == url), None)
     assert site is not None
     assert site["consecutive_failures"] >= count
@@ -98,31 +95,29 @@ async def then_failure_count(quarantine_context, count):
 # Cenario: Falhas intermitentes
 # ============================================================================
 
+
 @given("auditorias de um site com falhas em dias alternados")
-@pytest.mark.asyncio
-async def given_intermittent_failures(quarantine_context, storage):
-    quarantine_context["storage"] = storage
+def given_intermittent_failures(quarantine_context, storage_sync):
+    quarantine_context["storage"] = storage_sync
     url = "https://site-intermitente.gov.br"
     quarantine_context["test_url"] = url
 
     # Inserir falhas em dias alternados (nao consecutivos)
-    for i in range(0, 10, 2):  # dias 0, 2, 4, 6, 8
-        await storage.conn.execute("""
-            INSERT INTO audits (url, timestamp, error_message)
-            VALUES (?, ?, ?)
-        """, [
-            url,
-            datetime.utcnow() - timedelta(days=i),
-            "Intermittent error"
-        ])
+    for idx, i in enumerate(range(0, 10, 2)):  # dias 0, 2, 4, 6, 8
+        storage_sync.conn.execute(
+            """
+            INSERT INTO audits (id, url, timestamp, error_message)
+            VALUES (?, ?, ?, ?)
+        """,
+            [idx + 1, url, datetime.utcnow() - timedelta(days=i), "Intermittent error"],
+        )
 
 
 @then("o site nao deve estar na quarentena")
-@pytest.mark.asyncio
-async def then_site_not_in_quarantine(quarantine_context):
+def then_site_not_in_quarantine(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     urls = [s["url"] for s in sites]
     assert url not in urls
 
@@ -131,39 +126,34 @@ async def then_site_not_in_quarantine(quarantine_context):
 # Cenario: Atualizar status
 # ============================================================================
 
+
 @given(parsers.parse('um site na quarentena com status "{status}"'))
-@pytest.mark.asyncio
-async def given_site_with_status(quarantine_context, status, storage):
-    quarantine_context["storage"] = storage
+def given_site_with_status(quarantine_context, status, storage_sync):
+    quarantine_context["storage"] = storage_sync
     url = "https://site-em-quarentena.gov.br"
     quarantine_context["test_url"] = url
 
-    await storage.conn.execute("""
-        INSERT INTO quarantine (url, first_failure, last_failure, consecutive_failures, status)
-        VALUES (?, ?, ?, ?, ?)
-    """, [
-        url,
-        datetime.utcnow() - timedelta(days=5),
-        datetime.utcnow(),
-        5,
-        status
-    ])
+    storage_sync.conn.execute(
+        """
+        INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """,
+        [1, url, datetime.utcnow() - timedelta(days=5), datetime.utcnow(), 5, status],
+    )
 
 
 @when(parsers.parse('eu atualizar o status para "{new_status}"'))
-@pytest.mark.asyncio
-async def when_update_status(quarantine_context, new_status):
+def when_update_status(quarantine_context, new_status):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    await storage.update_quarantine_status(url, new_status)
+    asyncio.run(storage.update_quarantine_status(url, new_status))
 
 
 @then(parsers.parse('o status do site deve ser "{expected_status}"'))
-@pytest.mark.asyncio
-async def then_status_should_be(quarantine_context, expected_status):
+def then_status_should_be(quarantine_context, expected_status):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     site = next((s for s in sites if s["url"] == url), None)
     assert site is not None
     assert site["status"] == expected_status
@@ -179,38 +169,34 @@ def then_updated_at_changed(quarantine_context):
 # Cenario: Marcar como URL errada
 # ============================================================================
 
+
 @given("um site na quarentena")
-@pytest.mark.asyncio
-async def given_site_in_quarantine(quarantine_context, storage):
-    quarantine_context["storage"] = storage
+def given_site_in_quarantine(quarantine_context, storage_sync):
+    quarantine_context["storage"] = storage_sync
     url = "https://url-antiga.gov.br"
     quarantine_context["test_url"] = url
 
-    await storage.conn.execute("""
-        INSERT INTO quarantine (url, first_failure, last_failure, consecutive_failures, status)
-        VALUES (?, ?, ?, ?, 'quarantined')
-    """, [
-        url,
-        datetime.utcnow() - timedelta(days=10),
-        datetime.utcnow(),
-        10
-    ])
+    storage_sync.conn.execute(
+        """
+        INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+        VALUES (?, ?, ?, ?, ?, 'quarantined')
+    """,
+        [1, url, datetime.utcnow() - timedelta(days=10), datetime.utcnow(), 10],
+    )
 
 
 @when(parsers.parse('eu atualizar o status para "{status}" com nota "{note}"'))
-@pytest.mark.asyncio
-async def when_update_with_note(quarantine_context, status, note):
+def when_update_with_note(quarantine_context, status, note):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    await storage.update_quarantine_status(url, status, notes=note)
+    asyncio.run(storage.update_quarantine_status(url, status, notes=note))
 
 
 @then(parsers.parse('a nota deve conter "{text}"'))
-@pytest.mark.asyncio
-async def then_note_contains(quarantine_context, text):
+def then_note_contains(quarantine_context, text):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     site = next((s for s in sites if s["url"] == url), None)
     assert site is not None
     assert text in (site["notes"] or "")
@@ -220,20 +206,19 @@ async def then_note_contains(quarantine_context, text):
 # Cenario: Remover da quarentena
 # ============================================================================
 
+
 @when("eu remover o site da quarentena")
-@pytest.mark.asyncio
-async def when_remove_from_quarantine(quarantine_context):
+def when_remove_from_quarantine(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    await storage.remove_from_quarantine(url)
+    asyncio.run(storage.remove_from_quarantine(url))
 
 
 @then("o site nao deve estar mais na quarentena")
-@pytest.mark.asyncio
-async def then_site_removed(quarantine_context):
+def then_site_removed(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     urls = [s["url"] for s in sites]
     assert url not in urls
 
@@ -242,30 +227,52 @@ async def then_site_removed(quarantine_context):
 # Cenario: Listar por status
 # ============================================================================
 
+
 @given(parsers.parse('{count:d} sites em quarentena com status "{status}"'))
-@pytest.mark.asyncio
-async def given_sites_with_status(quarantine_context, count, status, storage):
-    quarantine_context["storage"] = storage
+def given_sites_with_status(quarantine_context, count, status, storage_sync):
+    quarantine_context["storage"] = storage_sync
+
+    # Track IDs to avoid duplicates across multiple given steps
+    if "id_counter" not in quarantine_context:
+        quarantine_context["id_counter"] = 0
 
     for i in range(count):
+        quarantine_context["id_counter"] += 1
         url = f"https://site-{status}-{i}.gov.br"
-        await storage.conn.execute("""
-            INSERT INTO quarantine (url, first_failure, last_failure, consecutive_failures, status)
-            VALUES (?, ?, ?, ?, ?)
-        """, [
-            url,
-            datetime.utcnow() - timedelta(days=5),
-            datetime.utcnow(),
-            5,
-            status
-        ])
+        storage_sync.conn.execute(
+            """
+            INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """,
+            [quarantine_context["id_counter"], url, datetime.utcnow() - timedelta(days=5), datetime.utcnow(), 5, status],
+        )
+
+
+@given(parsers.parse('sites em quarentena com status "{status}"'))
+def given_sites_with_status_no_count(quarantine_context, status, storage_sync):
+    """Add sites without specifying a count (defaults to 2)."""
+    quarantine_context["storage"] = storage_sync
+
+    # Track IDs to avoid duplicates across multiple given steps
+    if "id_counter" not in quarantine_context:
+        quarantine_context["id_counter"] = 0
+
+    for i in range(2):  # Default to 2 sites
+        quarantine_context["id_counter"] += 1
+        url = f"https://site-{status}-{quarantine_context['id_counter']}.gov.br"
+        storage_sync.conn.execute(
+            """
+            INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """,
+            [quarantine_context["id_counter"], url, datetime.utcnow() - timedelta(days=5), datetime.utcnow(), 5, status],
+        )
 
 
 @when(parsers.parse('eu listar sites com status "{status}"'))
-@pytest.mark.asyncio
-async def when_list_by_status(quarantine_context, status):
+def when_list_by_status(quarantine_context, status):
     storage = quarantine_context["storage"]
-    sites = await storage.get_quarantined_sites(status=status)
+    sites = asyncio.run(storage.get_quarantined_sites(status=status))
     quarantine_context["listed_sites"] = sites
 
 
@@ -279,19 +286,18 @@ def then_site_count(quarantine_context, count):
 # Cenario: URLs para pular
 # ============================================================================
 
+
 @when("eu obter URLs para pular")
-@pytest.mark.asyncio
-async def when_get_skip_urls(quarantine_context):
+def when_get_skip_urls(quarantine_context):
     storage = quarantine_context["storage"]
-    urls = await storage.get_urls_to_skip_quarantine()
+    urls = asyncio.run(storage.get_urls_to_skip_quarantine())
     quarantine_context["skip_urls"] = urls
 
 
 @then(parsers.parse('as URLs com status "{status}" devem ser retornadas'))
-@pytest.mark.asyncio
-async def then_urls_returned(quarantine_context, status):
+def then_urls_returned(quarantine_context, status):
     storage = quarantine_context["storage"]
-    sites = await storage.get_quarantined_sites(status=status)
+    sites = asyncio.run(storage.get_quarantined_sites(status=status))
     skip_urls = quarantine_context["skip_urls"]
 
     for site in sites:
@@ -299,10 +305,9 @@ async def then_urls_returned(quarantine_context, status):
 
 
 @then(parsers.parse('as URLs com status "{status}" nao devem ser retornadas'))
-@pytest.mark.asyncio
-async def then_urls_not_returned(quarantine_context, status):
+def then_urls_not_returned(quarantine_context, status):
     storage = quarantine_context["storage"]
-    sites = await storage.get_quarantined_sites(status=status)
+    sites = asyncio.run(storage.get_quarantined_sites(status=status))
     skip_urls = quarantine_context["skip_urls"]
 
     for site in sites:
@@ -313,30 +318,33 @@ async def then_urls_not_returned(quarantine_context, status):
 # Cenario: Estatisticas
 # ============================================================================
 
+
 @given("sites em quarentena com varios status")
-@pytest.mark.asyncio
-async def given_various_status(quarantine_context, storage):
-    quarantine_context["storage"] = storage
+def given_various_status(quarantine_context, storage_sync):
+    quarantine_context["storage"] = storage_sync
 
     statuses = ["quarantined", "quarantined", "investigating", "resolved", "wrong_url"]
     for i, status in enumerate(statuses):
-        await storage.conn.execute("""
-            INSERT INTO quarantine (url, first_failure, last_failure, consecutive_failures, status)
-            VALUES (?, ?, ?, ?, ?)
-        """, [
-            f"https://site-{i}.gov.br",
-            datetime.utcnow() - timedelta(days=i+3),
-            datetime.utcnow(),
-            i + 3,
-            status
-        ])
+        storage_sync.conn.execute(
+            """
+            INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """,
+            [
+                i + 1,
+                f"https://site-{i}.gov.br",
+                datetime.utcnow() - timedelta(days=i + 3),
+                datetime.utcnow(),
+                i + 3,
+                status,
+            ],
+        )
 
 
 @when("eu solicitar estatisticas da quarentena")
-@pytest.mark.asyncio
-async def when_get_stats(quarantine_context):
+def when_get_stats(quarantine_context):
     storage = quarantine_context["storage"]
-    stats = await storage.get_quarantine_stats()
+    stats = asyncio.run(storage.get_quarantine_stats())
     quarantine_context["stats"] = stats
 
 
@@ -368,58 +376,62 @@ def then_see_max_failures(quarantine_context):
 # Cenario: Site volta a funcionar
 # ============================================================================
 
+
 @given("um site em quarentena que voltou a funcionar")
-@pytest.mark.asyncio
-async def given_recovered_site(quarantine_context, storage):
-    quarantine_context["storage"] = storage
+def given_recovered_site(quarantine_context, storage_sync):
+    quarantine_context["storage"] = storage_sync
     url = "https://site-recuperado.gov.br"
     quarantine_context["test_url"] = url
 
     # Site estava em quarentena
-    await storage.conn.execute("""
-        INSERT INTO quarantine (url, first_failure, last_failure, consecutive_failures, status)
-        VALUES (?, ?, ?, ?, 'quarantined')
-    """, [
-        url,
-        datetime.utcnow() - timedelta(days=10),
-        datetime.utcnow() - timedelta(days=2),
-        8
-    ])
+    storage_sync.conn.execute(
+        """
+        INSERT INTO quarantine (id, url, first_failure, last_failure, consecutive_failures, status)
+        VALUES (?, ?, ?, ?, ?, 'quarantined')
+    """,
+        [
+            1,
+            url,
+            datetime.utcnow() - timedelta(days=10),
+            datetime.utcnow() - timedelta(days=2),
+            8,
+        ],
+    )
 
 
 @when("eu executar uma nova auditoria com sucesso")
-@pytest.mark.asyncio
-async def when_successful_audit(quarantine_context):
+def when_successful_audit(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
 
     # Nova auditoria bem-sucedida
-    await storage.conn.execute("""
-        INSERT INTO audits (url, timestamp, error_message)
-        VALUES (?, ?, NULL)
-    """, [url, datetime.utcnow()])
+    storage.conn.execute(
+        """
+        INSERT INTO audits (id, url, timestamp, error_message)
+        VALUES (?, ?, ?, NULL)
+    """,
+        [1, url, datetime.utcnow()],
+    )
 
 
 @then("o site pode ser removido da quarentena")
-@pytest.mark.asyncio
-async def then_can_be_removed(quarantine_context):
+def then_can_be_removed(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
-    sites = await storage.get_quarantined_sites()
+    sites = asyncio.run(storage.get_quarantined_sites())
     site = next((s for s in sites if s["url"] == url), None)
     # O site ainda esta na quarentena ate ser removido manualmente
     assert site is not None
 
 
 @then("futuras coletas devem incluir este site")
-@pytest.mark.asyncio
-async def then_future_collections_include(quarantine_context):
+def then_future_collections_include(quarantine_context):
     storage = quarantine_context["storage"]
     url = quarantine_context["test_url"]
 
     # Atualizar para resolved
-    await storage.update_quarantine_status(url, "resolved")
+    asyncio.run(storage.update_quarantine_status(url, "resolved"))
 
     # Verificar que nao esta mais na lista de skip
-    skip_urls = await storage.get_urls_to_skip_quarantine()
+    skip_urls = asyncio.run(storage.get_urls_to_skip_quarantine())
     assert url not in skip_urls


### PR DESCRIPTION
- Convert async BDD step functions to use asyncio.run() wrapper
- Add storage_sync fixture for BDD tests
- Fix DuckDB INSERT statements to include explicit IDs
- Fix consecutive failures detection SQL to properly identify consecutive dates (not just total failure count)
- Fix parameterized INTERVAL SQL syntax for DuckDB
- Fix mock test data types (version.major/minor as strings)
- Add missing step definition for sites without count

35 of 47 tests now pass (CLI, export, quarantine, metrics)

https://claude.ai/code/session_01ThanyQNhVwmkLzAjSgkbqh