### PR TITLE
design: make MkDocs the single dashboard shell authority

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Cal+Sans:wght@400;600;700&family=Space+Mono:wght@400;700&display=swap");
+
 * {
   margin: 0;
   padding: 0;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,112 +1,95 @@
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Acessibilidade Municipal - Comparador de Sites de Prefeituras</title>
-    <link href="https://unpkg.com/tabulator-tables@5.5.4/dist/css/tabulator.min.css" rel="stylesheet">
-    <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.5.4/dist/js/tabulator.min.js"></script>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cal+Sans:wght@400;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-</head>
-<body>
-    <header class="hero">
-        <div class="hero-content">
-            <h1 class="hero-title">Acessibilidade Municipal</h1>
-            <p class="hero-subtitle">Compare a acessibilidade digital dos sites de prefeituras brasileiras</p>
-            <div class="search-container">
-                <input type="text" id="citySearch" placeholder="Digite o nome da cidade ou estado..." class="search-input">
-                <button class="search-btn" onclick="searchCity()">Buscar</button>
-            </div>
+<header class="hero">
+    <div class="hero-content">
+        <h1 class="hero-title">Acessibilidade Municipal</h1>
+        <p class="hero-subtitle">Compare a acessibilidade digital dos sites de prefeituras brasileiras</p>
+        <div class="search-container">
+            <input type="text" id="citySearch" placeholder="Digite o nome da cidade ou estado..." class="search-input">
+            <button class="search-btn" onclick="searchCity()">Buscar</button>
         </div>
-        <div class="scroll-indicator">
-            <div class="scroll-arrow"></div>
-        </div>
-    </header>
+    </div>
+    <div class="scroll-indicator">
+        <div class="scroll-arrow"></div>
+    </div>
+</header>
 
-    <main class="main-content">
-        <section class="stats-section">
-            <div class="container">
-                <h2>Panorama Nacional</h2>
-                <div class="stats-grid">
-                    <div class="stat-card">
-                        <div class="stat-number" data-stat="total" data-count="0">0</div>
-                        <div class="stat-label">Sites Analisados</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-number" data-stat="avg-accessibility" data-count="0">0</div>
-                        <div class="stat-label">Acessibilidade Media</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-number" data-stat="avg-performance" data-count="0">0</div>
-                        <div class="stat-label">Performance Media</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-number" id="lastUpdated">-</div>
-                        <div class="stat-label">Ultima Atualizacao</div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <section class="ranking-section">
-            <div class="container">
-                <h2>Ranking de Acessibilidade</h2>
-                <div class="ranking-controls">
-                    <select id="stateFilter" class="filter-select">
-                        <option value="">Todos os Estados</option>
-                    </select>
-                    <select id="populationFilter" class="filter-select">
-                        <option value="">Todos os Tamanhos</option>
-                        <option value="big">Grandes (>500k)</option>
-                        <option value="medium">Medias (100k-500k)</option>
-                        <option value="small">Pequenas (<100k)</option>
-                    </select>
-                </div>
-                <div id="ranking-table"></div>
-            </div>
-        </section>
-
-        <section class="methodology-section">
-            <div class="container">
-                <h2>Metodologia</h2>
-                <div class="methodology-grid">
-                    <div class="methodology-card">
-                        <div class="methodology-icon">🎯</div>
-                        <h3>PageSpeed Insights</h3>
-                        <p>Analise automatizada usando a API do Google PageSpeed Insights</p>
-                    </div>
-                    <div class="methodology-card">
-                        <div class="methodology-icon">🤖</div>
-                        <h3>Coleta Diaria</h3>
-                        <p>Dados atualizados automaticamente via GitHub Actions</p>
-                    </div>
-                    <div class="methodology-card">
-                        <div class="methodology-icon">📊</div>
-                        <h3>Metricas WCAG</h3>
-                        <p>Scores de acessibilidade, performance, SEO e boas praticas</p>
-                    </div>
-                    <div class="methodology-card">
-                        <div class="methodology-icon">📱</div>
-                        <h3>Mobile First</h3>
-                        <p>Foco em dispositivos moveis, onde a maioria acessa</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-    </main>
-
-    <footer class="footer">
+<main class="main-content">
+    <section class="stats-section">
         <div class="container">
-            <p>&copy; 2024 Acessibilidade Municipal. Dados coletados com PageSpeed Insights.</p>
-            <p>
-                <a href="https://github.com/franklinbaldo/sites_prefeituras">GitHub</a> |
-                <a href="https://archive.org/details/psi_brazilian_city_audits">Internet Archive</a>
-            </p>
+            <h2>Panorama Nacional</h2>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-number" data-stat="total" data-count="0">0</div>
+                    <div class="stat-label">Sites Analisados</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number" data-stat="avg-accessibility" data-count="0">0</div>
+                    <div class="stat-label">Acessibilidade Media</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number" data-stat="avg-performance" data-count="0">0</div>
+                    <div class="stat-label">Performance Media</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number" id="lastUpdated">-</div>
+                    <div class="stat-label">Ultima Atualizacao</div>
+                </div>
+            </div>
         </div>
-    </footer>
+    </section>
 
-    <script src="js/script.js"></script>
-</body>
-</html>
+    <section class="ranking-section">
+        <div class="container">
+            <h2>Ranking de Acessibilidade</h2>
+            <div class="ranking-controls">
+                <select id="stateFilter" class="filter-select">
+                    <option value="">Todos os Estados</option>
+                </select>
+                <select id="populationFilter" class="filter-select">
+                    <option value="">Todos os Tamanhos</option>
+                    <option value="big">Grandes (>500k)</option>
+                    <option value="medium">Medias (100k-500k)</option>
+                    <option value="small">Pequenas (<100k)</option>
+                </select>
+            </div>
+            <div id="ranking-table"></div>
+        </div>
+    </section>
+
+    <section class="methodology-section">
+        <div class="container">
+            <h2>Metodologia</h2>
+            <div class="methodology-grid">
+                <div class="methodology-card">
+                    <div class="methodology-icon">🎯</div>
+                    <h3>PageSpeed Insights</h3>
+                    <p>Analise automatizada usando a API do Google PageSpeed Insights</p>
+                </div>
+                <div class="methodology-card">
+                    <div class="methodology-icon">🤖</div>
+                    <h3>Coleta Diaria</h3>
+                    <p>Dados atualizados automaticamente via GitHub Actions</p>
+                </div>
+                <div class="methodology-card">
+                    <div class="methodology-icon">📊</div>
+                    <h3>Metricas WCAG</h3>
+                    <p>Scores de acessibilidade, performance, SEO e boas praticas</p>
+                </div>
+                <div class="methodology-card">
+                    <div class="methodology-icon">📱</div>
+                    <h3>Mobile First</h3>
+                    <p>Foco em dispositivos moveis, onde a maioria acessa</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="container">
+        <p>&copy; 2024 Acessibilidade Municipal. Dados coletados com PageSpeed Insights.</p>
+        <p>
+            <a href="https://github.com/franklinbaldo/sites_prefeituras">GitHub</a> |
+            <a href="https://archive.org/details/psi_brazilian_city_audits">Internet Archive</a>
+        </p>
+    </div>
+</footer>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,10 +25,11 @@ theme:
 nav:
   - Início: index.md
 extra_css:
+  - https://unpkg.com/tabulator-tables@5.5.4/dist/css/tabulator.min.css
   - css/style.css
 extra_javascript:
-  - js/script.js
   - https://unpkg.com/tabulator-tables@5.5.4/dist/js/tabulator.min.js
+  - js/script.js
 plugins:
   - search
   - mermaid2


### PR DESCRIPTION
Fixes #65.

The dashboard page embedded a complete HTML document and loaded Tabulator/script assets directly inside `docs/index.md`, while MkDocs already owned the document shell and injected the same assets through `mkdocs.yml`. This could register dashboard JS more than once and left two competing stylesheet paths (`styles.css` vs `css/style.css`).

This PR:
- keeps `index.md` as page content only;
- makes `mkdocs.yml` the single authority for Tabulator CSS/JS and `js/script.js`;
- preserves Cal Sans/Space Mono through the canonical stylesheet;
- preserves all visible dashboard content and ranking behavior.

No filter/search/domain logic changes here; those remain in #64/#63. The docs deployment is already failing on main, so this PR must be evaluated against the same base failure rather than treated as live evidence for Cobogó #267.