### PR TITLE
design: use native dashboard interactions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,18 +2,18 @@
     <div class="hero-content">
         <h1 class="hero-title">Acessibilidade Municipal</h1>
         <p class="hero-subtitle">Compare a acessibilidade digital dos sites de prefeituras brasileiras</p>
-        <div class="search-container">
+        <form class="search-container" id="citySearchForm" role="search">
             <input type="text" id="citySearch" placeholder="Digite o nome da cidade ou estado..." class="search-input">
-            <button class="search-btn" onclick="searchCity()">Buscar</button>
-        </div>
+            <button class="search-btn" type="submit">Buscar</button>
+        </form>
     </div>
-    <div class="scroll-indicator">
-        <div class="scroll-arrow"></div>
-    </div>
+    <a class="scroll-indicator" href="#panorama-nacional" aria-label="Ir para o panorama nacional">
+        <span class="scroll-arrow" aria-hidden="true"></span>
+    </a>
 </header>
 
 <main class="main-content">
-    <section class="stats-section">
+    <section class="stats-section" id="panorama-nacional">
         <div class="container">
             <h2>Panorama Nacional</h2>
             <div class="stats-grid">

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -214,7 +214,7 @@ function populateStateFilter(data) {
   });
 }
 
-// Search functionality (called by button click or Enter key)
+// Search functionality
 function searchCity() {
   applyAllFiltersAndSearch();
 
@@ -241,29 +241,12 @@ async function initializeApp() {
   initStatsAnimation(summary);
   setupFilters();
 
-  // Setup search functionality
-  const searchInput = document.getElementById("citySearch");
-  if (searchInput) {
-    searchInput.addEventListener("keypress", function (e) {
-      if (e.key === "Enter") {
-        searchCity();
-      }
-    });
-  }
-
-  const searchButton = document.querySelector(".search-btn");
-  if (searchButton) {
-    searchButton.addEventListener("click", searchCity);
-  }
-
-  // Smooth scrolling for scroll indicator
-  const scrollIndicator = document.querySelector(".scroll-indicator");
-  if (scrollIndicator) {
-    scrollIndicator.addEventListener("click", function () {
-      const statsSection = document.querySelector(".stats-section");
-      if (statsSection) {
-        statsSection.scrollIntoView({ behavior: "smooth" });
-      }
+  // Native form submission covers both Enter and button activation exactly once.
+  const searchForm = document.getElementById("citySearchForm");
+  if (searchForm) {
+    searchForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      searchCity();
     });
   }
 


### PR DESCRIPTION
Fixes #64 on top of #66.

After #66 makes MkDocs the single asset authority, this PR fixes interaction semantics:

- the city search becomes a real `<form role="search">`;
- Enter and the submit button now share one `submit` handler instead of inline `onclick` + keypress + click handlers;
- the hero scroll affordance becomes a real anchor to `#panorama-nacional` instead of a clickable `<div>`;
- the decorative arrow is hidden from assistive technology.

Search/filter/domain logic and visible copy are preserved. This is stacked on #66 to keep shell cleanup separate from interaction behavior.