### PR TITLE
design: keep dashboard controls and freshness semantically explicit

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -260,6 +260,14 @@ body {
   flex-wrap: wrap;
 }
 
+.filter-control {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .filter-select {
   padding: 0.75rem 1.5rem;
   border: 2px solid var(--border-color);
@@ -415,6 +423,20 @@ body {
   padding: 2rem 0;
 }
 
+/* Accessible-only text remains available to assistive technology. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .search-container {
@@ -432,6 +454,7 @@ body {
     align-items: center;
   }
 
+  .filter-control,
   .filter-select {
     width: 100%;
     max-width: 300px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
         <h1 class="hero-title">Acessibilidade Municipal</h1>
         <p class="hero-subtitle">Compare a acessibilidade digital dos sites de prefeituras brasileiras</p>
         <form class="search-container" id="citySearchForm" role="search">
+            <label for="citySearch" class="visually-hidden">Buscar por cidade ou estado</label>
             <input type="text" id="citySearch" placeholder="Digite o nome da cidade ou estado..." class="search-input">
             <button class="search-btn" type="submit">Buscar</button>
         </form>
@@ -30,7 +31,7 @@
                     <div class="stat-label">Performance Media</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number" id="lastUpdated">-</div>
+                    <time class="stat-number" id="lastUpdated">-</time>
                     <div class="stat-label">Ultima Atualizacao</div>
                 </div>
             </div>
@@ -41,15 +42,21 @@
         <div class="container">
             <h2>Ranking de Acessibilidade</h2>
             <div class="ranking-controls">
-                <select id="stateFilter" class="filter-select">
-                    <option value="">Todos os Estados</option>
-                </select>
-                <select id="populationFilter" class="filter-select">
-                    <option value="">Todos os Tamanhos</option>
-                    <option value="big">Grandes (>500k)</option>
-                    <option value="medium">Medias (100k-500k)</option>
-                    <option value="small">Pequenas (<100k)</option>
-                </select>
+                <label class="filter-control" for="stateFilter">
+                    <span>Estado</span>
+                    <select id="stateFilter" class="filter-select">
+                        <option value="">Todos os Estados</option>
+                    </select>
+                </label>
+                <label class="filter-control" for="populationFilter">
+                    <span>Tamanho do município</span>
+                    <select id="populationFilter" class="filter-select">
+                        <option value="">Todos os Tamanhos</option>
+                        <option value="big">Grandes (>500k)</option>
+                        <option value="medium">Medias (100k-500k)</option>
+                        <option value="small">Pequenas (<100k)</option>
+                    </select>
+                </label>
             </div>
             <div id="ranking-table"></div>
         </div>

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -264,11 +264,12 @@ async function initializeApp() {
     });
   }
 
-  // Update last updated info
+  // Update last updated info while preserving the exact timestamp.
   if (summary && summary.generated_at) {
     const lastUpdatedEl = document.getElementById("lastUpdated");
     if (lastUpdatedEl) {
       const date = new Date(summary.generated_at);
+      lastUpdatedEl.setAttribute("datetime", summary.generated_at);
       lastUpdatedEl.textContent = date.toLocaleString("pt-BR");
     }
   }


### PR DESCRIPTION
Fixes #63 on top of #67.

This PR gives the data-reading controls persistent semantics without changing ranking logic:

- the city search gets a real `<label for>` kept visually hidden so the placeholder remains an example, not the field name;
- state and municipality-size filters get persistent visible labels;
- the dashboard freshness value becomes native `<time>` and receives the exact `summary.generated_at` in `datetime` while preserving the existing localized visible timestamp.

A small `.visually-hidden` utility and restrained filter-label layout are added to the existing stylesheet. Search/filter behavior, data, thresholds and ranking output are unchanged.

This remains source-tier consumer work while the docs deployment is unhealthy and does not promote Cobogó #267.