### PR TITLE
design: restore clear keyboard focus on dashboard controls

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -131,6 +131,11 @@ body {
   transform: scale(1.02);
 }
 
+.search-input:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 3px;
+}
+
 .search-btn {
   padding: 1rem 2rem;
   background: var(--primary-color);
@@ -281,6 +286,11 @@ body {
 .filter-select:focus {
   outline: none;
   border-color: var(--primary-color);
+}
+
+.filter-select:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .ranking-list {


### PR DESCRIPTION
Fixes #71 on top of #68.

The dashboard CSS removed native outlines from the search input and ranking filters. This PR keeps the existing background/scale/border cues but restores an explicit keyboard-only focus indicator:

- search input: 3px white ring with offset, chosen for the purple hero surface;
- filters: 3px existing primary-blue ring with offset against the white controls/page.

No layout, search/filter behavior, colors at rest, or domain logic changes. This stays separate from labeling/time semantics in #68.