### PR TITLE
design: keep stat animation away from freshness

### DIFF
--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -64,7 +64,7 @@ function initStatsAnimation(summary) {
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
-        const statNumbers = entry.target.querySelectorAll(".stat-number");
+        const statNumbers = entry.target.querySelectorAll(".stat-number[data-count]");
         statNumbers.forEach((stat) => {
           const target = parseFloat(stat.dataset.count);
           animateCounter(stat, target);


### PR DESCRIPTION
Fixes #74.

`initStatsAnimation()` selected every `.stat-number`, including the freshness element, which intentionally has no `data-count`. That produced `NaN` as the animation target and could keep an interval alive overwriting the timestamp.

This PR narrows the selector to `.stat-number[data-count]`. Counter timing, numeric stats, freshness formatting and dashboard data are otherwise untouched.